### PR TITLE
feat(Documentation): adds Transfer and Compute Action Providers to the documentation panel.

### DIFF
--- a/src/components/DocumentationBrowser/DocumentationBrowser.tsx
+++ b/src/components/DocumentationBrowser/DocumentationBrowser.tsx
@@ -29,10 +29,66 @@ import {
 } from "./library";
 import { useEffect, useRef, useState } from "react";
 
+const ActionProviderItem = ({ ap }: { ap: ActionProviderEntry }) => {
+  return (
+    <AccordionItem>
+      <h3>
+        <AccordionButton>
+          <Box as="span" flex="1" textAlign="left">
+            {ap.definition?.title ?? ap.url}
+          </Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h3>
+      <AccordionPanel pb={4}>
+        {ap.definition?.subtitle ? (
+          <Box>
+            <Text>{ap.definition?.subtitle ?? ""}</Text>
+            <Code variant="outline" colorScheme="pink" my={2}>
+              {ap.definition?.globus_auth_scope}
+            </Code>
+          </Box>
+        ) : null}
+        <Flex>
+          <ButtonGroup>
+            <Button
+              as={Link}
+              href={ap.url}
+              isExternal
+              size={"xs"}
+              variant={"outline"}
+            >
+              Definition
+              <ExternalLinkIcon mx="2px" />
+            </Button>
+            <Button
+              as={Link}
+              href={ap.documentation}
+              isExternal
+              size={"xs"}
+              variant={"outline"}
+            >
+              Documenation
+              <ExternalLinkIcon mx="2px" />
+            </Button>
+          </ButtonGroup>
+          <Spacer />
+          <Text fontSize="xs">{ap.definition?.admin_contact}</Text>
+        </Flex>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+};
+
 export function DocumentationBrowser() {
   const [actionProviders, setActionProviders] = useState<ActionProviderEntry[]>(
     [],
   );
+
+  const [actionProviderMenu, setActionProvidersMenu] = useState<{
+    main: ActionProviderEntry[];
+    transfer: ActionProviderEntry[];
+  }>({ main: [], transfer: [] });
 
   const boostraped = useRef(BOOTSTRAPPED);
 
@@ -43,6 +99,18 @@ export function DocumentationBrowser() {
     }
     execute();
   }, [boostraped]);
+
+  useEffect(() => {
+    const transfer = actionProviders.filter((ap) =>
+      ap.url.includes("transfer"),
+    );
+    const main = actionProviders.filter((ap) => !ap.url.includes("transfer"));
+
+    setActionProvidersMenu({
+      main,
+      transfer,
+    });
+  }, [actionProviders]);
 
   return (
     <Stack p={2}>
@@ -81,56 +149,26 @@ export function DocumentationBrowser() {
         </CardHeader>
         <CardBody>
           <Accordion allowMultiple>
-            {actionProviders.map((ap) => {
-              return (
-                <AccordionItem key={ap.url}>
-                  <h3>
-                    <AccordionButton>
-                      <Box as="span" flex="1" textAlign="left">
-                        {ap.definition?.title ?? ap.url}
-                      </Box>
-                      <AccordionIcon />
-                    </AccordionButton>
-                  </h3>
-                  <AccordionPanel pb={4}>
-                    {ap.definition?.subtitle ? (
-                      <Box>
-                        <Text>{ap.definition?.subtitle ?? ""}</Text>
-                        <Code variant="outline" colorScheme="pink" my={2}>
-                          {ap.definition?.globus_auth_scope}
-                        </Code>
-                      </Box>
-                    ) : null}
-                    <Flex>
-                      <ButtonGroup>
-                        <Button
-                          as={Link}
-                          href={ap.url}
-                          isExternal
-                          size={"xs"}
-                          variant={"outline"}
-                        >
-                          Definition
-                          <ExternalLinkIcon mx="2px" />
-                        </Button>
-                        <Button
-                          as={Link}
-                          href={ap.documentation}
-                          isExternal
-                          size={"xs"}
-                          variant={"outline"}
-                        >
-                          Documenation
-                          <ExternalLinkIcon mx="2px" />
-                        </Button>
-                      </ButtonGroup>
-                      <Spacer />
-                      <Text fontSize="xs">{ap.definition?.admin_contact}</Text>
-                    </Flex>
-                  </AccordionPanel>
-                </AccordionItem>
-              );
-            })}
+            {actionProviderMenu.main.map((ap) => (
+              <ActionProviderItem ap={ap} key={ap.url} />
+            ))}
+            <AccordionItem>
+              <h3>
+                <AccordionButton>
+                  <Box as="span" flex="1" textAlign="left">
+                    Globus Transfer
+                  </Box>
+                  <AccordionIcon />
+                </AccordionButton>
+              </h3>
+              <AccordionPanel pb={4}>
+                <Accordion allowMultiple>
+                  {actionProviderMenu.transfer.map((ap) => (
+                    <ActionProviderItem ap={ap} key={ap.url} />
+                  ))}
+                </Accordion>
+              </AccordionPanel>
+            </AccordionItem>
           </Accordion>
         </CardBody>
       </Card>

--- a/src/components/DocumentationBrowser/library.ts
+++ b/src/components/DocumentationBrowser/library.ts
@@ -33,6 +33,10 @@ export const ACTION_PROVIDERS: ActionProviderEntry[] = [
     url: "https://actions.globus.org/hello_world",
     documentation:
       "https://docs.globus.org/api/flows/hosted-action-providers/ap-hello-world/",
+    /**
+     * @todo Once the CORs errors are addressed, the "Hello World" definition can be removed.
+     * We're just using the full definition here FPO.
+     */
     definition: {
       admin_contact: "support@globus.org",
       administered_by: [],
@@ -67,6 +71,55 @@ export const ACTION_PROVIDERS: ActionProviderEntry[] = [
       types: ["ACTION"],
       visible_to: ["public"],
     },
+  },
+  {
+    url: "https://transfer.actions.globus.org/collection_info",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/collection-info/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/gcp/create_guest_collection",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/create-guest-collection-gcp/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/gcsv5/create_guest_collection",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/create-guest-collection-gcsv5/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/delete",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/delete/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/ls",
+    documentation: "https://docs.globus.org/api/transfer/action-providers/ls/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/mkdir",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/mkdir/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/manage_permission",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/manage-permission/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/stat",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/stat/",
+  },
+  {
+    url: "https://transfer.actions.globus.org/transfer",
+    documentation:
+      "https://docs.globus.org/api/transfer/action-providers/transfer/",
+  },
+  {
+    url: "https://compute.actions.globus.org",
+    documentation:
+      "https://globus-compute.readthedocs.io/en/latest/actionprovider.html",
   },
   {
     url: "https://actions.globus.org/search/ingest",


### PR DESCRIPTION
- AP information pulled from https://docs.globus.org/api/transfer/action-providers/ and https://docs.globus.org/api/flows/hosted-action-providers/#compute
- Added some very simple grouping for Transfer Action Providers (there are a few!).