### PR TITLE
fix: correct misspellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 ### Bug Fixes
 
-* ensure sessions are refereshed on load, prompt for sign in on failure ([#129](https://github.com/globus/flows-ide/issues/129)) ([6fecf78](https://github.com/globus/flows-ide/commit/6fecf78491ab5df67e25912ed773e23893adacd2))
+* ensure sessions are refreshed on load, prompt for sign in on failure ([#129](https://github.com/globus/flows-ide/issues/129)) ([6fecf78](https://github.com/globus/flows-ide/commit/6fecf78491ab5df67e25912ed773e23893adacd2))
 
 ## [1.4.1](https://github.com/globus/flows-ide/compare/flows-ide-v1.4.0...flows-ide-v1.4.1) (2024-09-18)
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -14,18 +14,18 @@ export const MODES = {
 
 export type SupportedModes = keyof typeof MODES;
 
-function isDefinitionMode(settings?: InteralSettings) {
+function isDefinitionMode(settings?: InternalSettings) {
   return settings?.mode === MODES.DEFINITION || !settings?.mode;
 }
 
-type InteralSettings = {
+type InternalSettings = {
   mode?: SupportedModes;
   enableExperimentalValidation?: boolean;
 };
 
 function configureEditor(
   monaco: Monaco,
-  settings: InteralSettings = {
+  settings: InternalSettings = {
     mode: MODES.DEFINITION,
     enableExperimentalValidation: true,
   },
@@ -51,7 +51,7 @@ function configureEditor(
 }
 
 export default function Editor(
-  props: { settings?: InteralSettings } & EditorProps,
+  props: { settings?: InternalSettings } & EditorProps,
 ) {
   return (
     <>


### PR DESCRIPTION
Corrects misspellings of 'refreshed', 'Internal', and 'Definition' in the codebase.